### PR TITLE
chore: bump to 1.0.1-alpha.0 for next development iteration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "1.0.0"
+version = "1.0.1-alpha.0"
 edition = "2024"
 authors = ["Brian Martin <brian@iop.systems>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
Bump version to `1.0.1-alpha.0` for next development iteration after the v1.0.0 release.