### PR TITLE
fix: use PR workflow for dev version bump in tag-release

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     # Only run if the commit message starts with "release: v" (matches merge commit titles)
     if: "startsWith(github.event.head_commit.message, 'release: v')"
 
@@ -53,6 +54,8 @@ jobs:
 
       - name: Bump to next dev version
         if: steps.check_tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_TOKEN }}
         run: |
           # Calculate next dev version (patch bump + alpha.0)
           VERSION="${{ steps.version.outputs.version }}"
@@ -60,13 +63,21 @@ jobs:
           NEXT_DEV="${MAJOR}.${MINOR}.$((PATCH + 1))-alpha.0"
           echo "Bumping to next dev version: $NEXT_DEV"
 
-          # Update Cargo.toml version
+          # Create branch, update version, and open PR
+          BRANCH="chore/bump-${NEXT_DEV}"
+          git checkout -b "$BRANCH"
+
           sed -i "0,/^version = \"${VERSION}\"/s//version = \"${NEXT_DEV}\"/" Cargo.toml
 
-          # Commit and push
           git add Cargo.toml
           git commit -m "chore: bump to ${NEXT_DEV} for next development iteration"
-          git push origin main
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: bump to ${NEXT_DEV} for next development iteration" \
+            --body "Automated version bump after v${VERSION} release." \
+            --head "$BRANCH" \
+            --base main
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary
- Update tag-release workflow to create a branch + PR for the dev version bump instead of pushing directly to main
- Branch protection prevents direct pushes, so the previous approach would always fail

## Test plan
- [ ] Verify next release triggers tag-release and the dev bump PR is created correctly