### PR TITLE
release: v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-04-06
+
+### Added
+
+- `SampleQuantiles` trait with `quantiles()` and `quantile()` methods, implemented
+  for both `Histogram` and `SparseHistogram`
+- `QuantilesResult` struct returning a `BTreeMap<Quantile, Bucket>` with
+  `total_count`, `min`, and `max` bucket metadata
+- `Quantile` newtype wrapping validated `f64` in `0.0..=1.0`, implementing
+  `Ord`/`Eq` for use as a `BTreeMap` key
+- `Error::InvalidQuantile` variant for quantile validation errors
+
+### Deprecated
+
+- `Histogram::percentiles()` and `Histogram::percentile()` — use `SampleQuantiles`
+  trait methods instead
+- `SparseHistogram::percentiles()` and `SparseHistogram::percentile()` — use
+  `SampleQuantiles` trait methods instead
+- `Error::InvalidPercentile` — use `Error::InvalidQuantile` instead
+
 ## [1.0.0] - 2026-03-20
 
 First release with changelog.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "1.0.1-alpha.0"
+version = "1.1.0"
 edition = "2024"
 authors = ["Brian Martin <brian@iop.systems>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Release v1.1.0

This PR prepares the release of v1.1.0.

### Changes
- Version bump to 1.1.0
- Changelog update

### After Merge
The tag-release workflow will automatically:
1. Create git tag `v1.1.0`
2. Trigger CI + publish to crates.io
3. Create a GitHub Release
4. Bump to next development version (`1.1.1-alpha.0`)

---
See CHANGELOG.md for details.

https://claude.ai/code/session_01YQAY65y5zF3PdR2uuaypMj