### PR TITLE
release: v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.0] - 2026-04-22
+
+### Added
+
+- `CumulativeROHistogram`, a read-only histogram variant with cumulative
+  (prefix-sum) counts that enables O(log n) quantile lookups via binary search
+  (with a linear-scan fallback for cache-line-sized data)
+- `From<&Histogram>` and `From<&SparseHistogram>` conversions for constructing
+  a `CumulativeROHistogram`
+- Quantile range query methods on `CumulativeROHistogram` for analytics use
+  cases
+
 ## [1.1.0] - 2026-04-06
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "1.1.0"
+version = "1.2.0"
 edition = "2024"
 authors = ["Brian Martin <brian@iop.systems>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Release v1.2.0

This PR prepares the release of v1.2.0.

### Changes
- Version bump to 1.2.0
- Changelog entry for `CumulativeROHistogram` (added in #7)

### After Merge
The tag-release workflow will automatically:
1. Create git tag `v1.2.0`
2. Trigger CI + publish to crates.io
3. Create a GitHub Release
4. Bump to next development version (`-alpha.0`)

---
See CHANGELOG.md for details.

**Note:** The commit must be squash-merged so the merge commit message starts with `release: v` for `tag-release.yml` to pick it up.