### PR TITLE
Add GitHub repo link to h2histogram site TOC

### DIFF
--- a/site/src/template.html
+++ b/site/src/template.html
@@ -68,6 +68,26 @@
           margin-bottom: 0.5rem;
         }
 
+        aside.toc .toc-repo {
+          display: inline-flex;
+          align-items: center;
+          gap: 0.4rem;
+          font-size: 13px;
+          color: var(--theme-foreground-muted);
+          text-decoration: none;
+          margin-bottom: 1rem;
+          padding-bottom: 0.75rem;
+          border-bottom: 1px solid var(--theme-foreground-faintest);
+        }
+
+        aside.toc .toc-repo:hover {
+          color: var(--theme-foreground);
+        }
+
+        aside.toc .toc-repo svg {
+          flex-shrink: 0;
+        }
+
         aside.toc ol {
           list-style: none;
           padding: 0;
@@ -102,6 +122,12 @@
   <body>
     <main></main>
     <aside class="toc" aria-label="On this page">
+      <a class="toc-repo" href="https://github.com/iopsystems/histogram" target="_blank" rel="noopener noreferrer">
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+          <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
+        </svg>
+        iopsystems/histogram
+      </a>
       <nav>
         <div class="toc-title">On this page</div>
         <ol id="toc-list"></ol>

--- a/site/src/template.html
+++ b/site/src/template.html
@@ -32,6 +32,28 @@
         align-items: start;
       }
 
+      header.repo-header {
+        grid-column: 1 / -1;
+        padding: 0.75rem 1.5rem 0;
+      }
+
+      header.repo-header a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        font: 12px/1 var(--sans-serif);
+        color: var(--theme-foreground-muted);
+        text-decoration: none;
+      }
+
+      header.repo-header a:hover {
+        color: var(--theme-foreground);
+      }
+
+      header.repo-header svg {
+        flex-shrink: 0;
+      }
+
       main {
         min-width: 0;
         padding-left: 1.5rem;
@@ -68,26 +90,6 @@
           margin-bottom: 0.5rem;
         }
 
-        aside.toc .toc-repo {
-          display: inline-flex;
-          align-items: center;
-          gap: 0.4rem;
-          font-size: 13px;
-          color: var(--theme-foreground-muted);
-          text-decoration: none;
-          margin-bottom: 1rem;
-          padding-bottom: 0.75rem;
-          border-bottom: 1px solid var(--theme-foreground-faintest);
-        }
-
-        aside.toc .toc-repo:hover {
-          color: var(--theme-foreground);
-        }
-
-        aside.toc .toc-repo svg {
-          flex-shrink: 0;
-        }
-
         aside.toc ol {
           list-style: none;
           padding: 0;
@@ -120,14 +122,16 @@
     </style>
   </head>
   <body>
-    <main></main>
-    <aside class="toc" aria-label="On this page">
-      <a class="toc-repo" href="https://github.com/iopsystems/histogram" target="_blank" rel="noopener noreferrer">
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <header class="repo-header">
+      <a href="https://github.com/iopsystems/histogram" target="_blank" rel="noopener noreferrer">
+        <svg width="14" height="14" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
           <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.012 8.012 0 0 0 16 8c0-4.42-3.58-8-8-8z"/>
         </svg>
         iopsystems/histogram
       </a>
+    </header>
+    <main></main>
+    <aside class="toc" aria-label="On this page">
       <nav>
         <div class="toc-title">On this page</div>
         <ol id="toc-list"></ol>


### PR DESCRIPTION
Adds a static link to iopsystems/histogram at the top of the right-rail "On this page" minimap, with the GitHub mark icon and a divider separating it from the auto-generated TOC entries. Visible only on screens >=1080px (existing TOC breakpoint).