### PR TITLE
release: v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] - 2026-04-29
+
+### Added
+
+- `Histogram32`, `AtomicHistogram32`, `SparseHistogram32`, and
+  `CumulativeROHistogram32` — u32-counter sibling types for all four histogram
+  variants, generated from shared declarative macros
+- Sealed `Count` and `AtomicCount` traits abstracting the bucket counter width
+  (implemented for `u32`/`u64` and their atomic counterparts)
+- Cross-width widening `From` conversions (u32 → u64) for all four histogram
+  families
+- Cross-width narrowing `TryFrom` conversions (u64 → u32) for `Histogram`,
+  `SparseHistogram`, and `CumulativeROHistogram`
+- Cross-variant + narrowing `TryFrom` paths for the snapshot pipeline:
+  `Histogram` → `CumulativeROHistogram32`, `Histogram` → `SparseHistogram32`,
+  and `SparseHistogram` → `CumulativeROHistogram32`
+- u32 benchmark cases for `Histogram` and `AtomicHistogram`
+- `rezolus_memory` example comparing `Histogram`, `SparseHistogram`, and
+  `CumulativeROHistogram` memory footprints from Rezolus parquet recordings
+- README "Counter Width" and "Recommended Pipeline" sections, with matching
+  rustdoc in `lib.rs`
+
+### Changed
+
+- `CumulativeROHistogram` cache-line threshold for linear-vs-binary search is
+  now count-type-dependent (`64 / size_of::<C>()`); `total_count` and
+  `individual_count` continue to return `u64`
+
 ## [1.2.0] - 2026-04-22
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "1.2.0-alpha.2"
+version = "1.3.0"
 edition = "2024"
 authors = ["Brian Martin <brian@iop.systems>", "Yao Yue <yao@iop.systems>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Release v1.3.0

This PR prepares the release of v1.3.0.

### Highlights

- u32-counter sibling types (`Histogram32`, `AtomicHistogram32`, `SparseHistogram32`, `CumulativeROHistogram32`) generated from shared declarative macros, plus sealed `Count` / `AtomicCount` traits
- Cross-width (`u32 ↔ u64`) and cross-variant `From` / `TryFrom` conversions covering the recommended snapshot pipeline
- New `rezolus_memory` example comparing `Histogram` / `SparseHistogram` / `CumulativeROHistogram` memory footprints from Rezolus parquet recordings
- README and rustdoc additions: "Counter Width" and "Recommended Pipeline"

### Changes

- Version bump `1.2.0-alpha.2` → `1.3.0`
- CHANGELOG entries moved into the new `[1.3.0] - 2026-04-29` section

### After Merge

The `tag-release` workflow will automatically:
1. Create git tag `v1.3.0`
2. Trigger CI + publish to crates.io
3. Create a GitHub Release
4. Bump to next development version (`1.3.1-alpha.0`)

---
See CHANGELOG.md for full details.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JheT1wcLKVSUf9avkDXei3)_