### PR TITLE
release: v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] - 2026-04-29
+
 ### Added
 
 - `CumulativeROHistogramRef<'a>` / `CumulativeROHistogram32Ref<'a>` and

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "1.3.1-alpha.0"
+version = "1.3.1"
 edition = "2024"
 authors = ["Brian Martin <brian@iop.systems>", "Yao Yue <yao@iop.systems>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Release v1.3.1

This PR prepares the release of v1.3.1.

### Changes
- Version bump to 1.3.1
- Changelog update

### After Merge
The tag-release workflow will automatically:
1. Create git tag `v1.3.1`
2. Trigger CI + publish to crates.io
3. Create a GitHub Release
4. Bump to next development version (`-alpha.0`)

---
See CHANGELOG.md for details.