### PR TITLE
Validate from_parts_unchecked inputs in debug builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- `from_parts_unchecked` on `CumulativeROHistogramRef` /
+  `CumulativeROHistogram32Ref` / `SparseHistogramRef` /
+  `SparseHistogram32Ref` now runs the same validation as `from_parts`
+  inside a `debug_assert!`. Debug builds catch invariant violations at
+  the call site; release builds are unchanged (validation is elided).
+
 ## [1.3.1] - 2026-04-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "1.3.1"
+version = "1.3.2-alpha.0"
 edition = "2024"
 authors = ["Brian Martin <brian@iop.systems>", "Yao Yue <yao@iop.systems>"]
 license = "MIT OR Apache-2.0"

--- a/src/cumulative.rs
+++ b/src/cumulative.rs
@@ -360,15 +360,30 @@ macro_rules! define_cumulative_histogram {
 
             /// Creates a borrowed view without validating invariants.
             ///
-            /// # Safety
+            /// Skips the O(n) validation pass that `from_parts` performs.
+            /// Intended for hot paths where the caller already guarantees the
+            /// invariants (e.g. data produced by this crate or validated once
+            /// at load time).
+            ///
+            /// # Contract
             ///
             /// Caller must ensure `index` and `count` satisfy the same invariants
-            /// as the owned `from_parts`.
+            /// as the owned `from_parts`. Misuse produces incorrect quantile
+            /// output rather than memory unsafety, which is why this is a safe
+            /// `fn`. In debug builds, the invariants are checked via
+            /// `debug_assert!`; release builds skip the check entirely.
             pub fn from_parts_unchecked(
                 config: Config,
                 index: &'a [u32],
                 count: &'a [$count],
             ) -> Self {
+                debug_assert!(
+                    Self::validate(&config, index, count).is_ok(),
+                    concat!(
+                        stringify!($ref_name),
+                        "::from_parts_unchecked called with invalid inputs"
+                    ),
+                );
                 Self {
                     config,
                     index,
@@ -1129,5 +1144,42 @@ mod tests {
             SampleQuantiles::quantiles(&r, qs).unwrap(),
             SampleQuantiles::quantiles(&owned, qs).unwrap()
         );
+    }
+
+    // Debug-only safety net: `from_parts_unchecked` should panic in debug
+    // builds when handed inputs that violate the invariants. Release builds
+    // skip the check entirely (no panic), so these tests only run when
+    // debug assertions are enabled.
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "from_parts_unchecked called with invalid inputs")]
+    fn ref_from_parts_unchecked_debug_panics_on_length_mismatch() {
+        let config = Config::new(7, 32).unwrap();
+        let _ = CumulativeROHistogramRef::from_parts_unchecked(config, &[1, 3], &[10]);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "from_parts_unchecked called with invalid inputs")]
+    fn ref_from_parts_unchecked_debug_panics_on_non_ascending_indices() {
+        let config = Config::new(7, 32).unwrap();
+        let _ = CumulativeROHistogramRef::from_parts_unchecked(config, &[3, 1], &[10u64, 40]);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "from_parts_unchecked called with invalid inputs")]
+    fn ref_from_parts_unchecked_debug_panics_on_decreasing_counts() {
+        let config = Config::new(7, 32).unwrap();
+        let _ = CumulativeROHistogramRef::from_parts_unchecked(config, &[1, 3], &[40u64, 10]);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "from_parts_unchecked called with invalid inputs")]
+    fn ref32_from_parts_unchecked_debug_panics_on_zero_count() {
+        let config = Config::new(7, 32).unwrap();
+        let _ = CumulativeROHistogram32Ref::from_parts_unchecked(config, &[1], &[0u32]);
     }
 }

--- a/src/sparse.rs
+++ b/src/sparse.rs
@@ -466,15 +466,30 @@ macro_rules! define_sparse_histogram {
 
             /// Creates a borrowed view without validating invariants.
             ///
-            /// # Safety
+            /// Skips the O(n) validation pass that `from_parts` performs.
+            /// Intended for hot paths where the caller already guarantees the
+            /// invariants (e.g. data produced by this crate or validated once
+            /// at load time).
+            ///
+            /// # Contract
             ///
             /// Caller must ensure `index` and `count` satisfy the same invariants
-            /// as the owned `from_parts`.
+            /// as the owned `from_parts`. Misuse produces incorrect quantile
+            /// output rather than memory unsafety, which is why this is a safe
+            /// `fn`. In debug builds, the invariants are checked via
+            /// `debug_assert!`; release builds skip the check entirely.
             pub fn from_parts_unchecked(
                 config: Config,
                 index: &'a [u32],
                 count: &'a [$count],
             ) -> Self {
+                debug_assert!(
+                    Self::validate(&config, index, count).is_ok(),
+                    concat!(
+                        stringify!($ref_name),
+                        "::from_parts_unchecked called with invalid inputs"
+                    ),
+                );
                 Self {
                     config,
                     index,


### PR DESCRIPTION
## Summary

Adds `debug_assert!(Self::validate(...).is_ok())` inside `from_parts_unchecked` on the four borrowed-view types (`CumulativeROHistogramRef`, `CumulativeROHistogram32Ref`, `SparseHistogramRef`, `SparseHistogram32Ref`).

Debug builds now panic at the call site when a caller violates the slice invariants. Release builds are unchanged — the assertion compiles away, so the hot-path zero-allocation property the borrowed views are designed for still holds.

## Why

The [slice-based quantile API design](https://github.com/iopsystems/metriken/blob/claude/memory-optimization-NQZyr/docs/histogram-slice-api-plan.md) (the one v1.3.1 implemented) explicitly called for this:

> The unsafe `from_parts_unchecked` constructor needs debug-assertion-only validation under `cfg(debug_assertions)`.

It was missed in the v1.3.1 landing. This PR closes the gap.

The motivation is consumer-facing safety: columnar consumers like `metriken-query` build a fresh ref per snapshot per query (potentially hundreds of thousands of refs per percentile query). Misuse silently produces incorrect quantile output rather than memory unsafety, so a `debug_assert` is the right shape — devs/tests catch invariant violations immediately, production pays nothing.

## Changes

- `src/cumulative.rs`: `debug_assert` in the `from_parts_unchecked` macro body, plus four `#[should_panic]` tests under `#[cfg(debug_assertions)]` covering length mismatch, non-ascending indices, decreasing cumulative counts, and zero count (the last on the u32 variant).
- `src/sparse.rs`: same `debug_assert`. Existing sparse tests remain unchanged.
- Improved rustdoc on both `from_parts_unchecked` methods to clarify the contract and the debug-build semantics.
- `CHANGELOG.md`: entry under `[Unreleased]`.
- `Cargo.toml`: bump to `1.3.2-alpha.0` per the project's feature-PR versioning rule.

## Test plan

- [x] `cargo test` — 114 unit + 5 doctest, all pass (was 110 + 5; +4 new debug-only `should_panic` tests)
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo doc --no-deps` clean

## Out of scope

- Marking `from_parts_unchecked` as `unsafe fn`. The plan offers this as a conservative option but notes the misuse penalty is incorrect quantile output, not memory unsafety. Standard library precedent (e.g. `str::from_utf8_unchecked`) reserves `unsafe` for the latter; staying with safe `pub fn` + debug-assertion validation matches that bar.
- Trait-based view abstraction (`CumulativeRoView`). Considered in the plan as an alternative to the macro duplication; v1.3.1 went with macros and this PR keeps that.