### PR TITLE
release: v1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-05-19
+
+### Added
+
+- Midpoint-based `mean()` on `CumulativeROHistogram` / `CumulativeROHistogram32`
+  — the mean of all observations, estimated from bucket midpoints, computed
+  once at construction time across `from_parts`, `From<&Histogram>`, and
+  `From<&SparseHistogram>`. Returns `None` for an empty histogram.
+
+### Changed
+
+- `CumulativeROHistogram` / `CumulativeROHistogram32` no longer implement `Eq`
+  (they now store an `f64` mean); `PartialEq` is retained. The borrowed
+  `*Ref` view types are unaffected.
+
 ## [1.3.1] - 2026-04-29
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "1.4.0-alpha.0"
+version = "1.4.0"
 edition = "2024"
 authors = ["Brian Martin <brian@iop.systems>", "Yao Yue <yao@iop.systems>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Release v1.4.0

This PR prepares the release of v1.4.0.

### Changes
- Version bump `1.4.0-alpha.0` -> `1.4.0`
- Changelog update

### Highlights
- **Added**: midpoint-based `mean()` on `CumulativeROHistogram` / `CumulativeROHistogram32`, computed once at construction across `from_parts`, `From<&Histogram>`, and `From<&SparseHistogram>`; `None` for empty histograms.
- **Changed**: `CumulativeROHistogram*` no longer implement `Eq` (they now store an `f64`); `PartialEq` retained. Borrowed `*Ref` views unaffected. (Released as a minor bump per maintainer decision.)

### After Merge
The tag-release workflow will automatically:
1. Create git tag `v1.4.0`
2. Trigger CI + publish to crates.io
3. Create a GitHub Release
4. Bump to next development version (`-alpha.0`)

---
See CHANGELOG.md for details.

---
_Generated by [Claude Code](https://claude.ai/code/session_018jnFHZj1HLmmL98TR2JwcF)_