### PR TITLE
QuantileResult: Add into_entries

### DIFF
--- a/src/quantile.rs
+++ b/src/quantile.rs
@@ -134,6 +134,13 @@ impl QuantilesResult {
         &self.entries
     }
 
+    /// Returns the quantile-to-bucket mappings, sorted by quantile.
+    ///
+    /// Consumes self, returning the mapping by value instead of reference.
+    pub fn into_entries(self) -> BTreeMap<Quantile, Bucket> {
+        self.entries
+    }
+
     /// Look up the bucket for a specific quantile.
     pub fn get(&self, quantile: &Quantile) -> Option<&Bucket> {
         self.entries.get(quantile)


### PR DESCRIPTION
This allows users to consume the result, and, for example, perform iterator transformations without needing to borrow from the original result.

Fixes: https://github.com/iopsystems/histogram/issues/23