### PR TITLE
release: v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-07-01
+
+### Added
+
+- `QuantilesResult::into_entries()` — consumes the result and returns the
+  quantile-to-bucket `BTreeMap` by value, allowing iterator transformations
+  without borrowing from the original result.
+
 ## [1.4.1] - 2026-05-19
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "histogram"
-version = "1.4.1"
+version = "1.5.0"
 edition = "2024"
 authors = ["Brian Martin <brian@iop.systems>", "Yao Yue <yao@iop.systems>"]
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Release v1.5.0

This PR prepares the release of v1.5.0.

### Changes
- Version bump to 1.5.0
- Changelog update

### After Merge
The tag-release workflow will automatically:
1. Create git tag `v1.5.0`
2. Trigger CI + publish to crates.io
3. Create a GitHub Release
4. Bump to next development version (`-alpha.0`)

---
See CHANGELOG.md for details.